### PR TITLE
feat!: support parser options

### DIFF
--- a/lib/src/lint.dart
+++ b/lib/src/lint.dart
@@ -3,20 +3,27 @@ import 'parse.dart';
 import 'rules.dart';
 import 'types/commit.dart';
 import 'types/lint.dart';
+import 'types/parser.dart';
 import 'types/rule.dart';
 
 ///
 /// Lint commit [message] with configured [rules]
 ///
-Future<LintOutcome> lint(String message, Map<String, Rule> rules,
-    {bool? defaultIgnores, Iterable<String>? ignores}) async {
+Future<LintOutcome> lint(
+  String message,
+  Map<String, Rule> rules, {
+  ParserOptions? parserOptions,
+  bool? defaultIgnores,
+  Iterable<String>? ignores,
+}) async {
   /// Found a wildcard match, skip
   if (isIgnored(message, defaultIgnores: defaultIgnores, ignores: ignores)) {
     return LintOutcome(input: message, valid: true, errors: [], warnings: []);
   }
 
   /// Parse the commit message
-  final commit = message.isEmpty ? Commit.empty() : parse(message);
+  final commit =
+      message.isEmpty ? Commit.empty() : parse(message, options: parserOptions);
 
   if (commit.header.isEmpty && commit.body == null && commit.footer == null) {
     /// Commit is empty, skip

--- a/lib/src/load.dart
+++ b/lib/src/load.dart
@@ -6,6 +6,7 @@ import 'package:yaml/yaml.dart';
 
 import 'types/case.dart';
 import 'types/commitlint.dart';
+import 'types/parser.dart';
 import 'types/rule.dart';
 
 ///
@@ -31,11 +32,14 @@ Future<CommitLint> load(
     final rules = yaml?['rules'] as YamlMap?;
     final ignores = yaml?['ignores'] as YamlList?;
     final defaultIgnores = yaml?['defaultIgnores'] as bool?;
+    final parser = yaml?['parser'] as YamlMap?;
     final config = CommitLint(
-        rules: rules?.map((key, value) => MapEntry(key, _extractRule(value))) ??
-            {},
-        ignores: ignores?.cast(),
-        defaultIgnores: defaultIgnores);
+      rules:
+          rules?.map((key, value) => MapEntry(key, _extractRule(value))) ?? {},
+      ignores: ignores?.cast(),
+      defaultIgnores: defaultIgnores,
+      parser: parser != null ? ParserOptions.fromYaml(parser) : null,
+    );
     if (include != null) {
       final upstream = await load(include, directory: file.parent);
       return config.inherit(upstream);

--- a/lib/src/types/commitlint.dart
+++ b/lib/src/types/commitlint.dart
@@ -1,13 +1,21 @@
+import 'parser.dart';
 import 'rule.dart';
 
 class CommitLint {
-  CommitLint({this.rules = const {}, this.defaultIgnores, this.ignores});
+  CommitLint({
+    this.rules = const {},
+    this.defaultIgnores,
+    this.ignores,
+    this.parser,
+  });
 
   final Map<String, Rule> rules;
 
   final bool? defaultIgnores;
 
   final Iterable<String>? ignores;
+
+  final ParserOptions? parser;
 
   CommitLint inherit(CommitLint other) {
     return CommitLint(
@@ -20,6 +28,7 @@ class CommitLint {
         ...?other.ignores,
         ...?ignores,
       ],
+      parser: parser ?? other.parser,
     );
   }
 }

--- a/lib/src/types/parser.dart
+++ b/lib/src/types/parser.dart
@@ -1,0 +1,82 @@
+import 'package:yaml/yaml.dart';
+
+const _kHeaderPattern =
+    r'^(?<type>\w*)(?:\((?<scope>.*)\))?!?: (?<subject>.*)$';
+const _kHeaderCorrespondence = ['type', 'scope', 'subject'];
+
+const _kReferenceActions = [
+  'close',
+  'closes',
+  'closed',
+  'fix',
+  'fixes',
+  'fixed',
+  'resolve',
+  'resolves',
+  'resolved'
+];
+
+const _kIssuePrefixes = ['#'];
+const _kNoteKeywords = ['BREAKING CHANGE', 'BREAKING-CHANGE'];
+const _kMergePattern = r'^(Merge|merge)\s(.*)$';
+const _kRevertPattern =
+    r'^(?:Revert|revert:)\s"?(?<header>[\s\S]+?)"?\s*This reverts commit (?<hash>\w*)\.';
+const _kRevertCorrespondence = ['header', 'hash'];
+
+const _kMentionsPattern = r'@([\w-]+)';
+
+class ParserOptions {
+  final List<String> issuePrefixes;
+  final List<String> noteKeywords;
+  final List<String> referenceActions;
+  final String headerPattern;
+  final List<String> headerCorrespondence;
+  final String revertPattern;
+  final List<String> revertCorrespondence;
+  final String mergePattern;
+  final String mentionsPattern;
+
+  const ParserOptions({
+    this.issuePrefixes = _kIssuePrefixes,
+    this.noteKeywords = _kNoteKeywords,
+    this.referenceActions = _kReferenceActions,
+    this.headerPattern = _kHeaderPattern,
+    this.headerCorrespondence = _kHeaderCorrespondence,
+    this.revertPattern = _kRevertPattern,
+    this.revertCorrespondence = _kRevertCorrespondence,
+    this.mergePattern = _kMergePattern,
+    this.mentionsPattern = _kMentionsPattern,
+  });
+
+  ParserOptions copyWith(ParserOptions? other) {
+    return ParserOptions(
+      issuePrefixes: other?.issuePrefixes ?? issuePrefixes,
+      noteKeywords: other?.noteKeywords ?? noteKeywords,
+      referenceActions: other?.referenceActions ?? referenceActions,
+      headerPattern: other?.headerPattern ?? headerPattern,
+      headerCorrespondence: other?.headerCorrespondence ?? headerCorrespondence,
+      revertPattern: other?.revertPattern ?? revertPattern,
+      revertCorrespondence: other?.revertCorrespondence ?? revertCorrespondence,
+      mergePattern: other?.mergePattern ?? mergePattern,
+      mentionsPattern: other?.mentionsPattern ?? mentionsPattern,
+    );
+  }
+
+  static ParserOptions fromYaml(YamlMap yaml) {
+    return ParserOptions(
+      issuePrefixes:
+          List<String>.from(yaml['issuePrefixes'] ?? _kIssuePrefixes),
+      noteKeywords: List<String>.from(yaml['noteKeywords'] ?? _kNoteKeywords),
+      referenceActions:
+          List<String>.from(yaml['referenceActions'] ?? _kReferenceActions),
+      headerPattern: yaml['headerPattern'] ?? _kHeaderPattern,
+      headerCorrespondence: List<String>.from(
+          yaml['headerCorrespondence'] ?? _kHeaderCorrespondence),
+      revertPattern: yaml['revertPattern'] ?? _kRevertPattern,
+      revertCorrespondence: List<String>.from(
+          yaml['revertCorrespondence'] ?? _kRevertCorrespondence),
+      mergePattern: yaml['mergePattern'] ?? _kMergePattern,
+      mentionsPattern: yaml['mentionsPattern'] ?? _kMentionsPattern,
+    );
+  }
+}

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -3,6 +3,7 @@
 import 'package:collection/collection.dart';
 import 'package:commitlint_cli/src/parse.dart';
 import 'package:commitlint_cli/src/types/commit.dart';
+import 'package:commitlint_cli/src/types/parser.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -253,6 +254,22 @@ void main() {
           '# ------------------------ >8 ------------------------\n' +
           'this is a line that should be truncated\n');
       expect(commit.body, equals('this is some body before a scissors-line'));
+    });
+
+    test('should use custom parser options with headerPattern', () {
+      final commit = parse('type(scope)-subject',
+          options: ParserOptions(headerPattern: r'^(\w*)(?:\((.*)\))?-(.*)$'));
+      expect(commit.header, equals('type(scope)-subject'));
+      expect(commit.scopes, equals(['scope']));
+      expect(commit.subject, equals('subject'));
+      expect(commit.type, equals('type'));
+    });
+
+    test('should use custom parser options with custom issuePrefixes', () {
+      final commit = parse('fix: change git convention to fix CD workflow sv-4',
+          options: ParserOptions(issuePrefixes: ['sv-']));
+      expect(commit.type, equals('fix'));
+      expect(commit.references.first.issue, equals('4'));
     });
 
     group('merge commits', () {


### PR DESCRIPTION
Support custom parser options configurated in `commitlint.yaml` under section `parser`.
``` yaml
parser:
  issuePrefixes:
    - XX
    - YY
  noteKeywords:
  referenceActions:
  headerPattern:
  headerCorrespondence:
  revertPattern:
  revertCorrespondence:
  mergePattern:
  mentionsPattern:


rules:
  type-case:
    - 2
    - always
    - lower-case
```

Currently supported options are listed in file `lib/src/types/parser.dart`

This will close #21 